### PR TITLE
Fix simple-server example code

### DIFF
--- a/docs/simple_server.md
+++ b/docs/simple_server.md
@@ -22,7 +22,7 @@ Goby's simple server support for different kinds of HTTP verb including the `GET
 Let's say we want to create a root path with a GET action:
 
 ```ruby
-server.get "\" do |request, response|
+server.get('/') do |request, response|
   response.status = 200
   response.body   = 'Hello Visitor!'
   response.set_header('Content-Type', 'text/plain')
@@ -43,7 +43,7 @@ require 'net/simple_server'
 
 server = Net::SimpleServer.new(3000) # Create a server instance with port 3000
 
-server.get('\') do |request, response|
+server.get('/') do |request, response|
   response.status = 200
   response.body   = 'Hello Visitor!'
   response.set_header('Content-Type', 'text/plain')


### PR DESCRIPTION
## Why & What
Simple-server example code seems to be broken. A single quote is escaped by a backslash in line 5. 
I fixed it.
cf. https://goby-lang.org/docs/simple-server.html

## Before

```
  1 require 'net/simple_server'
  2
  3 server = Net::SimpleServer.new(3000)
  4
  5 server.get('\') do |request, response|
  6   response.status = 200
  7   response.body   = 'Hello Visitor!'
  8   response.set_header('Content-Type', 'text/plain')
  9 end
 10
 11 server.start
```

```
$ goby simple_server.gb
expected next token to be ), got CONSTANT(Hello) instead. Line: 4
```

## After

```
  1 require 'net/simple_server'
  2
  3 server = Net::SimpleServer.new(3000)
  4
  5 server.get('/') do |request, response|
  6   response.status = 200
  7   response.body   = 'Hello Visitor!'
  8   response.set_header('Content-Type', 'text/plain')
  9 end
 10
 11 server.start
```

```
$ goby simple_server.gb
2018/05/31 15:10:42 SimpleServer start listening on port: 3000
```