### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -9,6 +9,11 @@
 const users = [];
 
 const siteConfig = {
+  algolia: {
+    apiKey: 'b023aa425d3aa0c853c2939891f07e19',
+    indexName: 'goby-lang',
+    algoliaOptions: {} // Optional, if provided by Algolia
+  },
   title: 'Goby',
   tagline: 'Inherits from Ruby, extended with Golang',
   url: 'https://goby-lang.org' /* your website url */,

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -12,7 +12,6 @@ const siteConfig = {
   algolia: {
     apiKey: 'b023aa425d3aa0c853c2939891f07e19',
     indexName: 'goby-lang',
-    algoliaOptions: {} // Optional, if provided by Algolia
   },
   title: 'Goby',
   tagline: 'Inherits from Ruby, extended with Golang',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.